### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -8,7 +8,7 @@
     "provides" : {
         "Lingua::EN::Stem::Porter" : "lib/Lingua/EN/Stem/Porter.pm6"
     },
-    "license": "The MIT License (MIT)",
+    "license": "MIT",
     "support" : { "source" : "https://github.com/johnspurr/Lingua-EN-Stem-Porter.git" },
     "tags" : ["NLP", "perl6", "stem", "porter"]
 }


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license